### PR TITLE
fix: cbook.Stack() is deprecated at matplotlib >= 3.8.0rc1

### DIFF
--- a/examples/example_basic/graph_widget.py
+++ b/examples/example_basic/graph_widget.py
@@ -177,7 +177,7 @@ class MatplotFigure(Widget):
         self.show_compare_cursor = False
         
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()       
         
         #legend management

--- a/examples/example_cursor_scatter/graph_widget_scatter.py
+++ b/examples/example_cursor_scatter/graph_widget_scatter.py
@@ -184,7 +184,7 @@ class MatplotFigureScatter(Widget):
         self.first_touch_pan = None
         
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()  
         
         #legend management

--- a/examples/example_twinx/graph_widget_twinx.py
+++ b/examples/example_twinx/graph_widget_twinx.py
@@ -210,7 +210,7 @@ class MatplotFigureTwinx(Widget):
         self.show_compare_cursor=False
 
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()  
 
         #legend management

--- a/kivy_matplotlib_widget/uix/graph_widget.py
+++ b/kivy_matplotlib_widget/uix/graph_widget.py
@@ -177,7 +177,7 @@ class MatplotFigure(Widget):
         self.show_compare_cursor = False
         
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()       
         
         #legend management

--- a/kivy_matplotlib_widget/uix/graph_widget_crop_factor.py
+++ b/kivy_matplotlib_widget/uix/graph_widget_crop_factor.py
@@ -152,7 +152,7 @@ class MatplotFigureCropFactor(Widget):
         self.anchor_y = None
 
         # manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
 
         self.bind(size=self._onSize)
 

--- a/kivy_matplotlib_widget/uix/graph_widget_scatter.py
+++ b/kivy_matplotlib_widget/uix/graph_widget_scatter.py
@@ -184,7 +184,7 @@ class MatplotFigureScatter(Widget):
         self.first_touch_pan = None
         
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()  
         
         #legend management

--- a/kivy_matplotlib_widget/uix/graph_widget_twinx.py
+++ b/kivy_matplotlib_widget/uix/graph_widget_twinx.py
@@ -210,7 +210,7 @@ class MatplotFigureTwinx(Widget):
         self.show_compare_cursor=False
 
         #manage back and next event
-        self._nav_stack = cbook.Stack()
+        self._nav_stack = cbook._Stack()
         self.set_history_buttons()  
 
         #legend management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "kivy>=2.0.0",
-    "matplotlib>=3.7.3"
+    "matplotlib>=3.5.2"
 ]
 keywords = ['android', 'python3', 'kivy', 'matplotlib']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "kivy_matplotlib_widget"
+dynamic = ["version"]
+description = "A Matplotlib interactive widget for kivy"
+authors = [
+  { name="mp-007", email="current.address@unknown.invalid" },
+  { name="T-Dynamos", email="anshdadwal298@mail.com" },
+]
+readme = {file = 'README.md', content-type='text/markdown', charset="UTF-8", variant="GFM"}
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "kivy>=2.0.0",
+    "matplotlib>=3.7.3"
+]
+keywords = ['android', 'python3', 'kivy', 'matplotlib']
+
+[tool.setuptools.dynamic]
+version = {attr = "kivy_matplotlib_widget.__init__.__version__"}
+
+[tool.setuptools.package-data]
+kivy_matplotlib_widget = ["fonts/*.ttf"]
+
+[project.urls]
+Homepage = "https://github.com/mp-007/kivy_matplotlib_widget"


### PR DESCRIPTION
Matplotlib made the method """Private""" by modifying Stack() to _Stack() at commit: ca2c0ff2abf41beb7b69f17bd5caad970812ad85 exactly July 12 of 2023.

If you try running the widget mp-007 at matplotlib version after July 12 of 2023 it will throw an exception:

AttributeError: module 'matplotlib.cbook' has no attribute 'Stack'. Did you mean: '_Stack'?

So I just modified the lines with cbook.Stack() with cbook._Stack() and the exception dissapears.

I think it's good to use newer versions because of:
    1. New API
    2. Faster methods
    3. Better Documentation